### PR TITLE
Add basic Fee SaaS implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,28 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-csv</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.twilio.sdk</groupId>
+                        <artifactId>twilio</artifactId>
+                        <version>9.3.1</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.razorpay</groupId>
+                        <artifactId>razorpay-java</artifactId>
+                        <version>1.4.4</version>
+                </dependency>
 
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/src/main/java/com/feeapp/feeapp/config/SecurityConfig.java
+++ b/src/main/java/com/feeapp/feeapp/config/SecurityConfig.java
@@ -1,0 +1,17 @@
+package com.feeapp.feeapp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/controller/DashboardController.java
+++ b/src/main/java/com/feeapp/feeapp/controller/DashboardController.java
@@ -1,0 +1,20 @@
+package com.feeapp.feeapp.controller;
+
+import com.feeapp.feeapp.repository.FeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final FeeRepository feeRepository;
+
+    @GetMapping("/")
+    public String dashboard(Model model) {
+        model.addAttribute("fees", feeRepository.findAll());
+        return "dashboard";
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/controller/FeeController.java
+++ b/src/main/java/com/feeapp/feeapp/controller/FeeController.java
@@ -1,0 +1,27 @@
+package com.feeapp.feeapp.controller;
+
+import com.feeapp.feeapp.entity.Fee;
+import com.feeapp.feeapp.repository.FeeRepository;
+import com.feeapp.feeapp.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/fee")
+@RequiredArgsConstructor
+public class FeeController {
+
+    private final FeeRepository feeRepository;
+    private final PaymentService paymentService;
+
+    @PostMapping("/remind/{id}")
+    public ResponseEntity<String> remind(@PathVariable Long id) {
+        Fee fee = feeRepository.findById(id).orElseThrow();
+        paymentService.sendPaymentLink(fee);
+        return ResponseEntity.ok("Reminder sent");
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/controller/PaymentController.java
+++ b/src/main/java/com/feeapp/feeapp/controller/PaymentController.java
@@ -1,0 +1,23 @@
+package com.feeapp.feeapp.controller;
+
+import com.feeapp.feeapp.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequestMapping("/api/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @GetMapping("/callback")
+    public ResponseEntity<String> callback(@RequestParam("linkId") String linkId) {
+        paymentService.markPaid(linkId);
+        return ResponseEntity.ok("Payment updated");
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/controller/UploadController.java
+++ b/src/main/java/com/feeapp/feeapp/controller/UploadController.java
@@ -1,0 +1,24 @@
+package com.feeapp.feeapp.controller;
+
+import com.feeapp.feeapp.service.CsvService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final CsvService csvService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) {
+        csvService.upload(file);
+        return ResponseEntity.ok("Uploaded");
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/entity/Fee.java
+++ b/src/main/java/com/feeapp/feeapp/entity/Fee.java
@@ -1,0 +1,27 @@
+package com.feeapp.feeapp.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Fee {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Student student;
+
+    private BigDecimal amount;
+
+    private LocalDate dueDate;
+
+    private boolean paid;
+}

--- a/src/main/java/com/feeapp/feeapp/entity/Payment.java
+++ b/src/main/java/com/feeapp/feeapp/entity/Payment.java
@@ -1,0 +1,22 @@
+package com.feeapp.feeapp.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private Fee fee;
+
+    private String linkId;
+
+    private String status;
+}

--- a/src/main/java/com/feeapp/feeapp/entity/Student.java
+++ b/src/main/java/com/feeapp/feeapp/entity/Student.java
@@ -1,0 +1,19 @@
+package com.feeapp.feeapp.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Student {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String phone;
+}

--- a/src/main/java/com/feeapp/feeapp/repository/FeeRepository.java
+++ b/src/main/java/com/feeapp/feeapp/repository/FeeRepository.java
@@ -1,0 +1,7 @@
+package com.feeapp.feeapp.repository;
+
+import com.feeapp.feeapp.entity.Fee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeeRepository extends JpaRepository<Fee, Long> {
+}

--- a/src/main/java/com/feeapp/feeapp/repository/PaymentRepository.java
+++ b/src/main/java/com/feeapp/feeapp/repository/PaymentRepository.java
@@ -1,0 +1,8 @@
+package com.feeapp.feeapp.repository;
+
+import com.feeapp.feeapp.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Payment findByLinkId(String linkId);
+}

--- a/src/main/java/com/feeapp/feeapp/repository/StudentRepository.java
+++ b/src/main/java/com/feeapp/feeapp/repository/StudentRepository.java
@@ -1,0 +1,7 @@
+package com.feeapp.feeapp.repository;
+
+import com.feeapp.feeapp.entity.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}

--- a/src/main/java/com/feeapp/feeapp/service/CsvService.java
+++ b/src/main/java/com/feeapp/feeapp/service/CsvService.java
@@ -1,0 +1,49 @@
+package com.feeapp.feeapp.service;
+
+import com.feeapp.feeapp.entity.Fee;
+import com.feeapp.feeapp.entity.Student;
+import com.feeapp.feeapp.repository.FeeRepository;
+import com.feeapp.feeapp.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class CsvService {
+
+    private final StudentRepository studentRepository;
+    private final FeeRepository feeRepository;
+
+    public void upload(MultipartFile file) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8));
+             CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader)) {
+            for (CSVRecord record : parser) {
+                String name = record.get("name");
+                String phone = record.get("phone");
+                BigDecimal amount = new BigDecimal(record.get("amount"));
+                LocalDate dueDate = LocalDate.parse(record.get("dueDate"));
+
+                Student student = studentRepository.save(Student.builder().name(name).phone(phone).build());
+                Fee fee = Fee.builder()
+                        .student(student)
+                        .amount(amount)
+                        .dueDate(dueDate)
+                        .paid(false)
+                        .build();
+                feeRepository.save(fee);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse CSV", e);
+        }
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/service/PaymentService.java
+++ b/src/main/java/com/feeapp/feeapp/service/PaymentService.java
@@ -1,0 +1,51 @@
+package com.feeapp.feeapp.service;
+
+import com.feeapp.feeapp.entity.Fee;
+import com.feeapp.feeapp.entity.Payment;
+import com.feeapp.feeapp.repository.FeeRepository;
+import com.feeapp.feeapp.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final FeeRepository feeRepository;
+    private final PaymentRepository paymentRepository;
+    private final RazorpayService razorpayService;
+    private final TwilioService twilioService;
+
+    @Value("${APP_BASE_URL:http://localhost:8080}")
+    private String baseUrl;
+
+    public void sendPaymentLink(Fee fee) {
+        String callback = baseUrl + "/api/payment/callback";
+        String linkId = razorpayService.createPaymentLink(
+                fee.getStudent().getName(),
+                fee.getStudent().getPhone(),
+                fee.getAmount(),
+                callback
+        );
+        Payment payment = Payment.builder()
+                .fee(fee)
+                .linkId(linkId)
+                .status("PENDING")
+                .build();
+        paymentRepository.save(payment);
+        String message = "Please pay fees: https://rzp.io/i/" + linkId;
+        twilioService.sendSms(fee.getStudent().getPhone(), message);
+    }
+
+    public void markPaid(String linkId) {
+        Payment payment = paymentRepository.findByLinkId(linkId);
+        if (payment != null) {
+            payment.setStatus("PAID");
+            paymentRepository.save(payment);
+            Fee fee = payment.getFee();
+            fee.setPaid(true);
+            feeRepository.save(fee);
+        }
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/service/RazorpayService.java
+++ b/src/main/java/com/feeapp/feeapp/service/RazorpayService.java
@@ -1,0 +1,36 @@
+package com.feeapp.feeapp.service;
+
+import com.razorpay.PaymentLink;
+import com.razorpay.RazorpayClient;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+public class RazorpayService {
+
+    @Value("${RAZORPAY_KEY:none}")
+    private String key;
+    @Value("${RAZORPAY_SECRET:none}")
+    private String secret;
+
+    public String createPaymentLink(String name, String phone, BigDecimal amount, String callbackUrl) {
+        try {
+            RazorpayClient client = new RazorpayClient(key, secret);
+            JSONObject request = new JSONObject();
+            request.put("amount", amount.multiply(new BigDecimal(100))); // in paise
+            request.put("currency", "INR");
+            request.put("description", name + " fees");
+            request.put("customer", new JSONObject().put("contact", phone).put("name", name));
+            request.put("notify", new JSONObject().put("sms", 1));
+            request.put("callback_url", callbackUrl);
+            request.put("callback_method", "get");
+            PaymentLink link = client.paymentLink.create(request);
+            return link.get("id");
+        } catch (Exception e) {
+            throw new RuntimeException("Razorpay error", e);
+        }
+    }
+}

--- a/src/main/java/com/feeapp/feeapp/service/TwilioService.java
+++ b/src/main/java/com/feeapp/feeapp/service/TwilioService.java
@@ -1,0 +1,27 @@
+package com.feeapp.feeapp.service;
+
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TwilioService {
+
+    @Value("${TWILIO_SID:none}")
+    private String sid;
+    @Value("${TWILIO_AUTH:none}")
+    private String auth;
+    @Value("${TWILIO_NUMBER:+10000000000}")
+    private String from;
+
+    private void init() {
+        Twilio.init(sid, auth);
+    }
+
+    public void sendSms(String to, String body) {
+        init();
+        Message.creator(new PhoneNumber(to), new PhoneNumber(from), body).create();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=feeapp
+spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASS}
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Dashboard</title>
+</head>
+<body>
+<h1>Fees</h1>
+<table border="1">
+    <tr>
+        <th>Student</th>
+        <th>Amount</th>
+        <th>Due</th>
+        <th>Paid</th>
+    </tr>
+    <tr th:each="fee : ${fees}">
+        <td th:text="${fee.student.name}"></td>
+        <td th:text="${fee.amount}"></td>
+        <td th:text="${fee.dueDate}"></td>
+        <td th:text="${fee.paid}"></td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add entities Student, Fee and Payment
- repositories for persistence
- services for CSV upload, Twilio SMS and Razorpay links
- controllers for upload, payment, reminders and dashboard
- Thymeleaf dashboard page
- simple security config and datasource properties

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch ...)*

------
https://chatgpt.com/codex/tasks/task_e_68760531a954832ea4be854bd558a76a